### PR TITLE
esp: Rework saving of network credentials

### DIFF
--- a/esp/GBPlay/main/commands.c
+++ b/esp/GBPlay/main/commands.c
@@ -3,12 +3,9 @@
 #include <esp_log.h>
 
 #include "http.h"
-#include "hardware/storage.h"
 #include "hardware/wifi.h"
 
 #define DEFAULT_SCAN_LIST_SIZE 10
-#define SSID_STORAGE_KEY "wifi_ssid"
-#define PASS_STORAGE_KEY "wifi_pass"
 
 static struct {
     struct arg_lit* save;
@@ -21,6 +18,11 @@ static struct {
     struct arg_str* url;
     struct arg_end* end;
 } http_get_args;
+
+static struct {
+    struct arg_int* index;
+    struct arg_end* end;
+} load_connection_args;
 
 static int _wifi_scan(int argc, char** argv)
 {
@@ -52,13 +54,13 @@ static int _wifi_connect(int argc, char **argv)
     const char* ssid = wifi_connect_args.ssid->sval[0];
     const char* pass = wifi_connect_args.pass->sval[0];
 
-    if (wifi_connect_args.save->count > 0)
+    if (wifi_connect(ssid, pass))
     {
-        storage_set_string(SSID_STORAGE_KEY, ssid);
-        storage_set_string(PASS_STORAGE_KEY, pass);
+        wifi_save_network(ssid, pass);
+        return 0;
     }
 
-    return wifi_connect(ssid, pass) ? 0 : 1;
+    return 1;
 }
 
 static int _wifi_disconnect(int argc, char** argv)
@@ -111,23 +113,37 @@ static int _http_get(int argc, char** argv)
 
 int _load_connection(int argc, char** argv)
 {
-    int ret = 1;
-    char* ssid = storage_get_string(SSID_STORAGE_KEY);
-    char* pass = storage_get_string(PASS_STORAGE_KEY);
+    int nerrors = arg_parse(argc, argv, (void**)&load_connection_args);
+    if (nerrors != 0) {
+        arg_print_errors(stderr, load_connection_args.end, argv[0]);
+        return 1;
+    }
 
-    if (ssid == NULL || pass == NULL)
+    if (load_connection_args.index->count == 0)
     {
-        ESP_LOGI(__func__, "No saved credentials");
+        int saved_network_count = wifi_saved_network_count();
+
+        ESP_LOGI(__func__, "Total saved networks = %d", saved_network_count);
+        for (int i = 0; i < saved_network_count; ++i)
+        {
+            ESP_LOGI(__func__, "%d: %s", i, wifi_get_saved_network_by_index(i)->ssid);
+        }
+
+        return 0;
     }
     else
     {
-        ret = wifi_connect(ssid, pass) ? 0 : 1;
+        int index = load_connection_args.index->ival[0];
+        wifi_network_credentials* ap = wifi_get_saved_network_by_index(index);
+
+        if (ap == NULL)
+        {
+            ESP_LOGE(__func__, "No saved network with index %d", index);
+            return 1;
+        }
+
+        return wifi_connect(ap->ssid, ap->pass) ? 0 : 1;
     }
-
-    free(ssid);
-    free(pass);
-
-    return ret;
 }
 
 
@@ -202,11 +218,15 @@ static void _register_http_get()
 
 void _register_load_connection()
 {
+    load_connection_args.index = arg_int0(NULL, NULL, "[index]", "Index of saved network. Omit to list all saved networks.");
+    load_connection_args.end = arg_end(10 /* max error count */);
+
     const esp_console_cmd_t load_def = {
         .command = "load",
         .help = "Load saved network configuration",
         .hint = NULL,
-        .func = &_load_connection
+        .func = &_load_connection,
+        .argtable = &load_connection_args
     };
 
     ESP_ERROR_CHECK(esp_console_cmd_register(&load_def));

--- a/esp/GBPlay/main/commands.c
+++ b/esp/GBPlay/main/commands.c
@@ -56,7 +56,10 @@ static int _wifi_connect(int argc, char **argv)
 
     if (wifi_connect(ssid, pass))
     {
-        wifi_save_network(ssid, pass);
+        if (wifi_connect_args.save->count > 0)
+        {
+            wifi_save_network(ssid, pass);
+        }
         return 0;
     }
 

--- a/esp/GBPlay/main/hardware/storage.h
+++ b/esp/GBPlay/main/hardware/storage.h
@@ -4,6 +4,9 @@
 void storage_initialize();
 void storage_deinitialize();
 
+void* storage_get_blob(const char* key);
+void storage_set_blob(const char* key, const void* value, size_t length);
+
 char* storage_get_string(const char* key);
 void storage_set_string(const char* key, const char* value);
 

--- a/esp/GBPlay/main/hardware/wifi.h
+++ b/esp/GBPlay/main/hardware/wifi.h
@@ -5,23 +5,26 @@
 
 // Per 802.11 spec
 #define WIFI_MAX_SSID_LENGTH        32
+#define WIFI_MAX_PASS_LENGTH        64
 
 #define WIFI_MINIMUM_RSSI          -80
 #define WIFI_WEAK_RSSI_THRESHOLD   -70
 #define WIFI_MED_RSSI_THRESHOLD    -60
 #define WIFI_STRONG_RSSI_THRESHOLD -50
 
-#define WIFI_MAX_SAVED_NETWORKS     3
+#define WIFI_MAX_SAVED_NETWORKS     5
 
-
-// Defining our own type to keep this interface generic
-// TODO: multiple authentication types
 typedef struct {
     char ssid[WIFI_MAX_SSID_LENGTH + 1];
     int8_t channel;
     int8_t rssi;
     bool requires_password;
 } wifi_ap_info;
+
+typedef struct {
+    char ssid[WIFI_MAX_SSID_LENGTH + 1];
+    char pass[WIFI_MAX_PASS_LENGTH + 1];
+} wifi_network_credentials;
 
 void wifi_initialize();
 void wifi_deinitialize();
@@ -30,5 +33,11 @@ void wifi_scan(wifi_ap_info* ap_list, uint16_t* ap_count);
 bool wifi_connect(const char* ssid, const char* password);
 void wifi_disconnect();
 bool wifi_is_connected();
+
+int wifi_saved_network_count();
+wifi_network_credentials* wifi_get_saved_network(const char* ssid);
+wifi_network_credentials* wifi_get_saved_network_by_index(int index);
+bool wifi_save_network(const char* ssid, const char* password);
+void wifi_forget_network(const char* ssid);
 
 #endif


### PR DESCRIPTION
* Store up to 5 networks
* Support adding/removing
* Update "load connection" REPL command
    * Run with no arguments to list index and SSID for each saved network
    * Run with saved network index to connect to it

This will make it easier to implement the auto-reconnect logic (connection manager), and for users to configure the device.

TODO: make this all thread-safe (will do when implementing the connection manager).