### PR TITLE
esp: Thread safe wifi functions

### DIFF
--- a/esp/GBPlay/main/hardware/wifi.h
+++ b/esp/GBPlay/main/hardware/wifi.h
@@ -30,13 +30,12 @@ void wifi_initialize();
 void wifi_deinitialize();
 
 void wifi_scan(wifi_ap_info* ap_list, uint16_t* ap_count);
-bool wifi_connect(const char* ssid, const char* password);
+bool wifi_connect(const char* ssid, const char* password, bool force);
 void wifi_disconnect();
 bool wifi_is_connected();
 
-int wifi_saved_network_count();
-wifi_network_credentials* wifi_get_saved_network(const char* ssid);
-wifi_network_credentials* wifi_get_saved_network_by_index(int index);
+bool wifi_get_saved_network(const char* ssid, wifi_network_credentials* out_network);
+int wifi_get_all_saved_networks(wifi_network_credentials* out_networks);
 bool wifi_save_network(const char* ssid, const char* password);
 void wifi_forget_network(const char* ssid);
 

--- a/esp/GBPlay/main/tasks/status_indicator.c
+++ b/esp/GBPlay/main/tasks/status_indicator.c
@@ -27,7 +27,7 @@ void task_status_indicator_start()
     xTaskCreatePinnedToCore(
         &task_status_indicator,
         TASK_NAME,
-        configMINIMAL_STACK_SIZE,  // Stack size (in words)
+        configMINIMAL_STACK_SIZE,  // Stack size
         NULL,                      // Arguments
         0,                         // Priority
         NULL,                      // Task handle (output parameter)


### PR DESCRIPTION
We need to support multiple tasks configuring Wi-Fi at the same time (the connection manager and the user config interface). Even if the user config task has higher priority, we still don't want it getting in the middle of an in-progress operation (e.g., trying to connect while the connection manager is already doing so).

Locking for exclusive access also makes the experience smoother. Without these changes, if two tasks are scanning for available networks at the same time, one will see 0 results.