### PR TITLE
Fixed slave response control value

### DIFF
--- a/tools/common/bgb_link_cable_server.py
+++ b/tools/common/bgb_link_cable_server.py
@@ -110,7 +110,7 @@ class BGBLinkCableServer:
                 self._send_packet(
                     105,       # Slave data packet
                     response,  # Data value
-                    0x81       # Control value
+                    0x80       # Control value
                 )
         else:
             # Indicates no response from the GB


### PR DESCRIPTION
This changes the control value used in a response from the slave during `sync2`. [From the docs](https://bgb.bircd.org/bgblink.html):

```
105 - sync2
Send a byte as slave. This command is sent in response to receiving a sync1, if a passive transfer was started.

b2=data value
b3=control value, $80
b4=0
i1=0
```