### PR TITLE
Add content to main readme, and add readme for tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# gbplay
+# GBPlay: Online Game Boy Multiplayer
+
+GBPlay aims to enable Game Boy and Game Boy Color multiplayer over the internet
+using original hardware. This [has](http://pepijndevos.nl/TCPoke/) been done
+[before](https://www.youtube.com/watch?v=KtHu693wE9o), but existing projects are
+limited to one game, require a hard-wired connection to a PC, and are generally
+inaccessible to users without a technical background.
+
+Our goal is to create a solution that supports as much of the Game Boy library
+as possible and is plug and play, such that everything can be done entirely from
+the Game Boy. This will take the form of a small dongle with a link cable
+connector and Wi-Fi connectivity. Configuration will be done via a custom Game
+Boy cartridge, with a mobile-friendly web page as a backup option.
+
+Through this, we endeavor to learn more about hardware design, embedded systems,
+and retro devices as we find out just how far old technology can be pushed
+beyond what it was ever intended to do.
+
+The project is currently in an early/exploratory stage.
+Read more at [blog.gbplay.io](https://blog.gbplay.io).
+
+## Repository structure
+
+| Directory   | Description                                               |
+| ----------- | --------------------------------------------------------- |
+| `arduino/`  | Code for Arduino-based USB to Game Boy link cable adapter |
+| `captures/` | Annotated link cable communication logs for various games |
+| `docs/`     | Contents of [blog.gbplay.io](https://blog.gbplay.io)      |
+| `esp/`      | Code for firmware of ESP32-based Game Boy Wi-Fi interface |
+| `server/`   | Code for backend server                                   |
+| `tools/`    | Test scripts for development and debugging                |

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,27 @@
+# GBPlay tools
+
+This directory contains scripts for development and debugging.
+
+## Requirements
+
+* [Python 3](https://www.python.org/downloads/)
+* [BGB](https://bgb.bircd.org/) Game Boy emulator (for relevant tools/modes)
+* Run `pip install -r requirements.txt`
+
+Tools which communicate with a real Game Boy over serial require a serial to
+Game Boy adapter which will wait for a byte to be written by the host (PC), send
+it to the GB, and send the byte receieved from the GB back.
+
+An Arduino-based implementation of such an adapter can be found
+[in this repository](../arduino/gb_to_serial).
+
+## Directory index
+
+| Directory             | Description                                       |
+| -----------           | ------------------------------------------------- |
+| `bgb-serial-link/`    | Provides BGB <-> serial link cable communication  |
+| `common/`             | Code shared by multiple tools                     |
+| `pokered-mock-trade/` | Sends fake Pokemon trade data to a GB or emulator |
+| `tcp-serial-bridge/`  | Links GBs and/or emulators in slave mode via TCP  |
+
+All tools support the `--help` argument.

--- a/tools/common/serial_link_cable.py
+++ b/tools/common/serial_link_cable.py
@@ -2,8 +2,8 @@ from io import DEFAULT_BUFFER_SIZE
 import serial
 
 # Enables link cable communication with a Game Boy over serial. Requires a
-# serial <-> Game Boy adapter which will wait for a byte to be written by
-# the host (PC), send it to the GB, and send byte receievd from the GB back.
+# serial <-> Game Boy adapter which will wait for a byte to be written by the
+# host (PC), send it to the GB, and send the byte receieved from the GB back.
 #
 # An Arduino-based implementation of such an adapter can be found at
 # gbplay/arduino/gb_to_serial.


### PR DESCRIPTION
About time we had this.

I took most of the intro blurb from the [first blog post](https://blog.gbplay.io/2021/05/10/An-8-Bit-Idea_The-Internet-of-Game-Boys.html#improvements-and-goals).

Forest mentioned it was a bit unclear how the repo was organized so I also added descriptions for each top-level folder and a separate readme for `tools/`.