### PR TITLE
esp: Add SPI support

### DIFF
--- a/esp/GBPlay/main/CMakeLists.txt
+++ b/esp/GBPlay/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 # TODO: split up into separate components
 idf_component_register(
-    SRCS "GBPlay.c" "commands.c" "http.c" "hardware/led.c" "hardware/storage.c" "hardware/wifi.c" "tasks/connection_manager.c" "tasks/status_indicator.c"
+    SRCS "GBPlay.c" "commands.c" "http.c" "hardware/led.c" "hardware/spi.c" "hardware/storage.c" "hardware/wifi.c" "tasks/connection_manager.c" "tasks/status_indicator.c"
     INCLUDE_DIRS "."
 )

--- a/esp/GBPlay/main/GBPlay.c
+++ b/esp/GBPlay/main/GBPlay.c
@@ -6,6 +6,7 @@
 
 #include "commands.h"
 #include "hardware/led.h"
+#include "hardware/spi.h"
 #include "hardware/storage.h"
 #include "hardware/wifi.h"
 
@@ -46,6 +47,7 @@ void app_main()
 
     // Initialize hardware
     led_initialize();
+    spi_initialize();
     storage_initialize();
     wifi_initialize();
 
@@ -62,6 +64,7 @@ void app_main()
 
     wifi_deinitialize();
     storage_deinitialize();
+    spi_deinitialize();
 
     esp_event_loop_delete_default();
 }

--- a/esp/GBPlay/main/hardware/spi.c
+++ b/esp/GBPlay/main/hardware/spi.c
@@ -1,0 +1,54 @@
+#include <driver/spi_master.h>
+
+#include "spi.h"
+
+#define GB_SPI_MODE 3
+#define GB_SPI_CLOCK_SPEED_HZ 8000
+
+#define SPI_HOST SPI2_HOST
+#define PIN_MOSI SPI2_IOMUX_PIN_NUM_MOSI  // Pin 13
+#define PIN_MISO SPI2_IOMUX_PIN_NUM_MISO  // Pin 12
+#define PIN_SCLK SPI2_IOMUX_PIN_NUM_CLK   // Pin 14
+
+static spi_device_handle_t _spi_slave_handle = NULL;
+
+void spi_initialize()
+{
+    spi_bus_config_t bus_config = {
+        .mosi_io_num = PIN_MOSI,
+        .miso_io_num = PIN_MISO,
+        .sclk_io_num = PIN_SCLK,
+        .quadwp_io_num = -1,
+        .quadhd_io_num = -1,
+        .max_transfer_sz = 1,
+        .flags = SPICOMMON_BUSFLAG_MASTER,
+        .intr_flags = 0
+    };
+    ESP_ERROR_CHECK(spi_bus_initialize(SPI_HOST, &bus_config, SPI_DMA_DISABLED));
+
+    spi_device_interface_config_t dev_config = {0};
+    dev_config.mode = GB_SPI_MODE;
+    dev_config.clock_speed_hz = GB_SPI_CLOCK_SPEED_HZ;
+    dev_config.spics_io_num = -1;
+    dev_config.queue_size = 1;
+    ESP_ERROR_CHECK(spi_bus_add_device(SPI_HOST, &dev_config, &_spi_slave_handle));
+}
+
+void spi_deinitialize()
+{
+    spi_bus_remove_device(_spi_slave_handle);
+    spi_bus_free(SPI_HOST);
+}
+
+uint8_t spi_exchange_byte(uint8_t tx)
+{
+    uint8_t rx = 0xFF;
+
+    spi_transaction_t txn = {0};
+    txn.length = 8;  // In bits
+    txn.tx_buffer = &tx;
+    txn.rx_buffer = &rx;
+
+    ESP_ERROR_CHECK(spi_device_transmit(_spi_slave_handle, &txn));
+    return rx;
+}

--- a/esp/GBPlay/main/hardware/spi.h
+++ b/esp/GBPlay/main/hardware/spi.h
@@ -1,0 +1,19 @@
+#ifndef _SPI_H
+#define _SPI_H
+
+/* Configures the SPI interface for use. */
+void spi_initialize();
+
+/* Disables the SPI interface. */
+void spi_deinitialize();
+
+/*
+    Exchanges a byte with the SPI slave device.
+
+    @param tx The byte to send
+
+    @returns The received byte, or 0xFF if there was no response
+*/
+uint8_t spi_exchange_byte(uint8_t tx);
+
+#endif


### PR DESCRIPTION
Cleaned up my SPI code now that our problem is solved.

Uses SPI2/HSPI by default, with the Espressif library.It is worth investigating if this library adds latency since the transfers are so small. Bit banging may be more performant.

Also added a new command to send and receive SPI data interactively.

Next stop, wireless connection to the server!  