### PR TITLE
esp: Support data transfer between TCP server and GB link cable

### DIFF
--- a/esp/GBPlay/main/CMakeLists.txt
+++ b/esp/GBPlay/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 # TODO: split up into separate components
 idf_component_register(
-    SRCS "GBPlay.c" "commands.c" "http.c" "hardware/led.c" "hardware/spi.c" "hardware/storage.c" "hardware/wifi.c" "tasks/network_manager.c" "tasks/status_indicator.c"
+    SRCS "GBPlay.c" "commands.c" "http.c" "socket.c" "hardware/led.c" "hardware/spi.c" "hardware/storage.c" "hardware/wifi.c" "tasks/network_manager.c" "tasks/socket_manager.c" "tasks/status_indicator.c"
     INCLUDE_DIRS "."
 )

--- a/esp/GBPlay/main/CMakeLists.txt
+++ b/esp/GBPlay/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 # TODO: split up into separate components
 idf_component_register(
-    SRCS "GBPlay.c" "commands.c" "http.c" "hardware/led.c" "hardware/spi.c" "hardware/storage.c" "hardware/wifi.c" "tasks/connection_manager.c" "tasks/status_indicator.c"
+    SRCS "GBPlay.c" "commands.c" "http.c" "hardware/led.c" "hardware/spi.c" "hardware/storage.c" "hardware/wifi.c" "tasks/network_manager.c" "tasks/status_indicator.c"
     INCLUDE_DIRS "."
 )

--- a/esp/GBPlay/main/GBPlay.c
+++ b/esp/GBPlay/main/GBPlay.c
@@ -11,6 +11,7 @@
 #include "hardware/wifi.h"
 
 #include "tasks/network_manager.h"
+#include "tasks/socket_manager.h"
 #include "tasks/status_indicator.h"
 
 #define CONFIG_CONSOLE_MAX_COMMAND_LINE_LENGTH 1024
@@ -37,6 +38,8 @@ void start_tasks()
 {
     task_network_manager_start(0 /* core */, 2 /* priority */);
     task_status_indicator_start(0 /* core */, 1 /* priority */);
+
+    task_socket_manager_start(1 /* core */, 1 /* priority */);
 }
 
 void app_main()

--- a/esp/GBPlay/main/GBPlay.c
+++ b/esp/GBPlay/main/GBPlay.c
@@ -10,7 +10,7 @@
 #include "hardware/storage.h"
 #include "hardware/wifi.h"
 
-#include "tasks/connection_manager.h"
+#include "tasks/network_manager.h"
 #include "tasks/status_indicator.h"
 
 #define CONFIG_CONSOLE_MAX_COMMAND_LINE_LENGTH 1024
@@ -35,8 +35,8 @@ void init_console()
 
 void start_tasks()
 {
+    task_network_manager_start();
     task_status_indicator_start();
-    task_connection_manager_start();
 }
 
 void app_main()

--- a/esp/GBPlay/main/GBPlay.c
+++ b/esp/GBPlay/main/GBPlay.c
@@ -35,8 +35,8 @@ void init_console()
 
 void start_tasks()
 {
-    task_network_manager_start();
-    task_status_indicator_start();
+    task_network_manager_start(0 /* core */, 2 /* priority */);
+    task_status_indicator_start(0 /* core */, 1 /* priority */);
 }
 
 void app_main()

--- a/esp/GBPlay/main/hardware/storage.c
+++ b/esp/GBPlay/main/hardware/storage.c
@@ -68,3 +68,19 @@ void storage_set_string(const char* key, const char* value)
 
     ESP_LOGI(__func__, "Wrote string '%s' to storage", key);
 }
+
+void storage_delete(const char* key)
+{
+    esp_err_t err = nvs_erase_key(s_storage_handle, key);
+    if (err == ESP_ERR_NVS_NOT_FOUND)
+    {
+        ESP_LOGI(__func__, "Key '%s' does not exist in storage. Nothing to do.", key);
+    }
+    else
+    {
+        ESP_ERROR_CHECK(err);
+        ESP_LOGI(__func__, "Deleted '%s' from storage", key);
+    }
+
+    ESP_ERROR_CHECK(nvs_commit(s_storage_handle));
+}

--- a/esp/GBPlay/main/hardware/storage.h
+++ b/esp/GBPlay/main/hardware/storage.h
@@ -44,4 +44,11 @@ char* storage_get_string(const char* key);
 */
 void storage_set_string(const char* key, const char* value);
 
+/*
+    Removes a value from non-volatile storage.
+
+    @param key Identifier of the value
+*/
+void storage_delete(const char* key);
+
 #endif

--- a/esp/GBPlay/main/hardware/wifi.h
+++ b/esp/GBPlay/main/hardware/wifi.h
@@ -15,17 +15,17 @@
 
 #define WIFI_MAX_SAVED_NETWORKS     5
 
-ESP_EVENT_DECLARE_BASE(CONNECTION_EVENT);
+ESP_EVENT_DECLARE_BASE(NETWORK_EVENT);
 
 typedef enum {
-    CONNECTION_EVENT_DROPPED   = 1,     // Connection lost unexpectedly
-    CONNECTION_EVENT_LEFT      = 2,     // Connection intentionally closed
-    CONNECTION_EVENT_CONNECTED = 4      // Connection established
-} connection_event;
+    NETWORK_EVENT_DROPPED   = 1,     // Network connection lost unexpectedly
+    NETWORK_EVENT_LEFT      = 2,     // Network connection intentionally closed
+    NETWORK_EVENT_CONNECTED = 4      // Network connection established
+} network_event;
 
 typedef struct {
     char ssid[WIFI_MAX_SSID_LENGTH + 1];
-} connection_event_connected;
+} network_event_connected;
 
 typedef struct {
     char ssid[WIFI_MAX_SSID_LENGTH + 1];

--- a/esp/GBPlay/main/hardware/wifi.h
+++ b/esp/GBPlay/main/hardware/wifi.h
@@ -2,6 +2,7 @@
 #define _WIFI_H
 
 #include <stdint.h>
+#include <esp_event_base.h>
 
 // Per 802.11 spec
 #define WIFI_MAX_SSID_LENGTH        32
@@ -13,6 +14,18 @@
 #define WIFI_STRONG_RSSI_THRESHOLD -50
 
 #define WIFI_MAX_SAVED_NETWORKS     5
+
+ESP_EVENT_DECLARE_BASE(CONNECTION_EVENT);
+
+typedef enum {
+    CONNECTION_EVENT_DROPPED   = 1,     // Connection lost unexpectedly
+    CONNECTION_EVENT_LEFT      = 2,     // Connection intentionally closed
+    CONNECTION_EVENT_CONNECTED = 4      // Connection established
+} connection_event;
+
+typedef struct {
+    char ssid[WIFI_MAX_SSID_LENGTH + 1];
+} connection_event_connected;
 
 typedef struct {
     char ssid[WIFI_MAX_SSID_LENGTH + 1];
@@ -47,6 +60,8 @@ void wifi_scan(wifi_ap_info* out_ap_list, uint16_t* ap_count);
     @param ssid     SSID of network to connect to
     @param password Password of network to connect to
     @param force    Whether to connect even if already connected to a network
+
+    @returns Whether or not the connection succeeded
 */
 bool wifi_connect(const char* ssid, const char* password, bool force);
 

--- a/esp/GBPlay/main/socket.c
+++ b/esp/GBPlay/main/socket.c
@@ -1,0 +1,253 @@
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+
+#include <esp_log.h>
+
+#include "socket.h"
+
+static bool _set_socket_is_blocking(int sock, bool is_blocking)
+{
+    int flags = fcntl(sock, F_GETFL);
+    if (flags < 0)
+    {
+        ESP_LOGE(__func__, "Unable to get socket flags: errno %d", errno);
+        return false;
+    }
+
+    int new_flags = is_blocking ? (flags & ~O_NONBLOCK) : (flags | O_NONBLOCK);
+    if (fcntl(sock, F_SETFL, new_flags) < 0)
+    {
+        ESP_LOGE(__func__, "Unable to set socket flags: errno %d", errno);
+        return false;
+    }
+
+    return true;
+}
+
+static int _get_socket_error(int sock)
+{
+    int sock_error = 0;
+    socklen_t sock_error_len = sizeof(sock_error);
+
+    if (getsockopt(sock, SOL_SOCKET, SO_ERROR, &sock_error, &sock_error_len) < 0)
+    {
+        ESP_LOGE(__func__, "Failed to get socket error code: errno %d", errno);
+        sock_error = errno;
+    }
+
+    return sock_error;
+}
+
+static bool _wait_for_socket_connect(int sock, int timeout_ms)
+{
+    int64_t cutoff_time = esp_timer_get_time() + (timeout_ms * 1000);
+    bool success = true;
+
+    while (success)
+    {
+        int ms_to_wait = (cutoff_time - esp_timer_get_time()) / 1000;
+        if (ms_to_wait <= 0)
+        {
+            errno = ETIMEDOUT;
+            success = false;
+            break;
+        }
+
+        struct pollfd fds[] = {{
+            .fd = sock,
+            .events = POLLOUT  // Writable
+        }};
+        int rc = poll(fds, 1, timeout_ms);
+
+        if (rc == 0)
+        {
+            // poll() timed out
+            errno = ETIMEDOUT;
+            success = false;
+        }
+        else if (rc < 0 && errno != EINTR)
+        {
+            // poll() failed
+            ESP_LOGE(
+                __func__,
+                "Failed waiting for socket to connect: errno %d",
+                errno
+            );
+            success = false;
+        }
+        else if (rc > 0)
+        {
+            // poll() signaled socket as writable. Check for success.
+            int sock_error = _get_socket_error(sock);
+            if (sock_error == 0)
+            {
+                // Connected
+                break;
+            }
+
+            ESP_LOGE(__func__, "Socket unable to connect: errno %d", sock_error);
+            success = false;
+        }
+    }
+
+    if (errno == ETIMEDOUT)
+    {
+        ESP_LOGE(
+            __func__,
+            "Timed out waiting for socket connection after %d ms",
+            timeout_ms
+        );
+    }
+
+    return success;
+}
+
+static bool _connect_socket(int sock, struct addrinfo* address, int timeout_ms)
+{
+    // Temporarily switch to non-blocking so we can control the timeout
+    if (!_set_socket_is_blocking(sock, false))
+    {
+        ESP_LOGE(__func__, "Unable to set socket to non-blocking");
+        return false;
+    }
+
+    bool success = true;
+    if (connect(sock, address->ai_addr, address->ai_addrlen) < 0)
+    {
+        if (errno != EINPROGRESS)
+        {
+            ESP_LOGE(__func__, "Socket unable to connect: errno %d", errno);
+            success = false;
+        }
+        else
+        {
+            success = _wait_for_socket_connect(sock, timeout_ms);
+        }
+    }
+
+    if (!_set_socket_is_blocking(sock, true))
+    {
+        ESP_LOGE(__func__, "Unable to set socket to blocking");
+        success = false;
+    }
+
+    return success;
+}
+
+static int _create_socket(struct addrinfo* address, int timeout_ms)
+{
+    assert(address->ai_protocol == IPPROTO_TCP);
+
+    int sock = socket(address->ai_family, address->ai_socktype, address->ai_protocol);
+    if (sock < 0)
+    {
+        ESP_LOGE(__func__, "Unable to create socket: errno %d", errno);
+        return -1;
+    }
+
+    // Reduce latency
+    int nodelay_value = 1;
+    if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &nodelay_value, sizeof(nodelay_value)) != 0)
+    {
+        ESP_LOGE(__func__, "Unable to set socket options: errno %d", errno);
+        close(sock);
+        return -1;
+    }
+
+    if (!_connect_socket(sock, address, timeout_ms))
+    {
+        close(sock);
+        return -1;
+    }
+
+    return sock;
+}
+
+int socket_connect(const char* address, uint16_t port, int timeout_ms)
+{
+    struct addrinfo hints = {0};
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_protocol = IPPROTO_TCP;
+
+    char service[NI_MAXSERV] = {0};
+    snprintf(service, sizeof(service), "%d", port);
+    service[NI_MAXSERV - 1] = '\0';
+
+    struct addrinfo* address_info = NULL;
+    if (getaddrinfo(address, service, &hints, &address_info) != 0)
+    {
+        ESP_LOGE(__func__, "Could not get address info for %s:%d", address, port);
+        return -1;
+    }
+    else
+    {
+        int sock = -1;
+        for (struct addrinfo* a = address_info; a != NULL; a = a->ai_next)
+        {
+            sock = _create_socket(a, timeout_ms);
+            if (sock >= 0)
+            {
+                break;
+            }
+        }
+
+        freeaddrinfo(address_info);
+        return sock;
+    }
+}
+
+// TODO: detect unclean disconnect (read timeout)
+bool socket_read(int sock, uint8_t* out_buf, size_t buf_len)
+{
+    ssize_t bytes_read = 0;
+
+    while (bytes_read < buf_len)
+    {
+        ssize_t ret = recv(sock, out_buf + bytes_read, buf_len - bytes_read, 0);
+        if (ret == 0)
+        {
+            ESP_LOGE(__func__, "Socket closed when reading: errno %d", errno);
+            return false;
+        }
+        else if (ret == -1 && errno != EINTR)
+        {
+            ESP_LOGE(__func__, "Error reading socket data: errno %d", errno);
+            return false;
+        }
+        else if (ret > 0)
+        {
+            bytes_read += ret;
+        }
+    }
+
+    return true;
+}
+
+// TODO: detect unclean disconnect (write timeout)
+bool socket_write(int sock, const uint8_t* buf, size_t buf_len)
+{
+    ssize_t bytes_written = 0;
+
+    while (bytes_written < buf_len)
+    {
+        ssize_t ret = send(sock, buf + bytes_written, buf_len - bytes_written, 0);
+        if (ret == 0)
+        {
+            ESP_LOGE(__func__, "Socket closed when writing: errno %d", errno);
+            return false;
+        }
+        else if (ret == -1 && errno != EINTR)
+        {
+            ESP_LOGE(__func__, "Error writing socket data: errno %d", errno);
+            return false;
+        }
+        else if (ret > 0)
+        {
+            bytes_written += ret;
+        }
+    }
+
+    return true;
+}

--- a/esp/GBPlay/main/socket.h
+++ b/esp/GBPlay/main/socket.h
@@ -1,0 +1,39 @@
+#ifndef _SOCKET_H
+#define _SOCKET_H
+
+/*
+    Attempts to open a socket to the specified location.
+
+    @param address    Address to connect to
+    @param port       Port number to connect to
+    @param timeout_ms Number of milliseconds to wait before timing out
+
+    @returns The socket file descriptor, or -1 on error.
+*/
+int socket_connect(const char* address, uint16_t port, int timeout_ms);
+
+/*
+    Reads data from a socket. Returns once enough data has been read to
+    completely fill the specified buffer, or an error has occurred.
+
+    @param sock    File descriptor of socket to read from
+    @param out_buf [output] Buffer to store receieved data in
+    @param buf_len Length of receive buffer, out_buf
+
+    @returns Whether or not all of the data could be read from the socket.
+*/
+bool socket_read(int sock, uint8_t* out_buf, size_t buf_len);
+
+/*
+    Writes data to a socket. Returns once all of the data in the specified
+    buffer has been written, or an error has occurred.
+
+    @param sock    File descriptor of socket to write to
+    @param buf     Buffer to write to the socket
+    @param buf_len Length of send buffer, buf
+
+    @returns Whether or not all of the data could be written to the socket.
+*/
+bool socket_write(int sock, const uint8_t* buf, size_t buf_len);
+
+#endif

--- a/esp/GBPlay/main/tasks/network_manager.c
+++ b/esp/GBPlay/main/tasks/network_manager.c
@@ -204,7 +204,7 @@ static void task_network_manager(void* data)
     }
 }
 
-void task_network_manager_start()
+void task_network_manager_start(int core, int priority)
 {
     s_connection_event_group = xEventGroupCreate();
 
@@ -223,9 +223,9 @@ void task_network_manager_start()
         TASK_NAME,
         4096,                      // Stack size
         NULL,                      // Arguments
-        1,                         // Priority
+        priority,                  // Priority
         NULL,                      // Task handle (output parameter)
-        0                          // CPU core ID
+        core                       // CPU core ID
     );
 
     // Wake the task up and start looking for networks

--- a/esp/GBPlay/main/tasks/network_manager.c
+++ b/esp/GBPlay/main/tasks/network_manager.c
@@ -10,54 +10,54 @@
 
 #include "../hardware/wifi.h"
 
-#define TASK_NAME "connection-manager"
+#define TASK_NAME "network-manager"
 
 #define IDLE_SCAN_PERIOD_SECONDS    30
 #define SCAN_LIST_SIZE              10
-#define CONNECTION_HISTORY_SIZE     WIFI_MAX_SAVED_NETWORKS
+#define NETWORK_HISTORY_SIZE        WIFI_MAX_SAVED_NETWORKS
 #define MINUTE_MICROSECONDS         (60 * 1000 * 1000)
 #define NETWORK_BLOCK_MINUTES       5
 
 typedef struct {
     char ssid[WIFI_MAX_SSID_LENGTH + 1];
     int64_t blocked_until;  // For blacklisting networks on disconnect
-} connection_info;
+} network_info;
 
-// Ring buffer of connection metadata
+// Ring buffer of metadata for previously-used networks
 typedef struct {
-    connection_info connections[CONNECTION_HISTORY_SIZE];
+    network_info used_networks[NETWORK_HISTORY_SIZE];
+    char prev_ssid[WIFI_MAX_SSID_LENGTH + 1];
     int next_index;
-} connection_history;
+} network_history;
 
 static EventGroupHandle_t s_connection_event_group;
-static char s_prev_ssid[WIFI_MAX_SSID_LENGTH + 1] = "";
-static connection_history s_connection_history = {0};
+static network_history s_network_history = {0};
 
 static void _on_disconnect(void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data)
 {
-    xEventGroupSetBits(s_connection_event_group, CONNECTION_EVENT_DROPPED);
+    xEventGroupSetBits(s_connection_event_group, NETWORK_EVENT_DROPPED);
 }
 
 static void _on_leave(void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data)
 {
-    xEventGroupSetBits(s_connection_event_group, CONNECTION_EVENT_LEFT);
+    xEventGroupSetBits(s_connection_event_group, NETWORK_EVENT_LEFT);
 }
 
 static void _on_connect(void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data)
 {
-    connection_event_connected* event = (connection_event_connected*)event_data;
+    network_event_connected* event = (network_event_connected*)event_data;
 
-    strncpy(s_prev_ssid, (char*)event->ssid, sizeof(s_prev_ssid));
-    s_prev_ssid[sizeof(s_prev_ssid) - 1] = '\0';
+    strncpy(s_network_history.prev_ssid, (char*)event->ssid, sizeof(s_network_history.prev_ssid));
+    s_network_history.prev_ssid[sizeof(s_network_history.prev_ssid) - 1] = '\0';
 
-    xEventGroupSetBits(s_connection_event_group, CONNECTION_EVENT_CONNECTED);
+    xEventGroupSetBits(s_connection_event_group, NETWORK_EVENT_CONNECTED);
 }
 
-static connection_info* _ensure_connection_info(const char* ssid)
+static network_info* _ensure_network_info(const char* ssid)
 {
-    for (int i = 0; i < CONNECTION_HISTORY_SIZE; ++i)
+    for (int i = 0; i < NETWORK_HISTORY_SIZE; ++i)
     {
-        connection_info* entry = &s_connection_history.connections[i];
+        network_info* entry = &s_network_history.used_networks[i];
         if (strcmp(entry->ssid, ssid) == 0)
         {
             return entry;
@@ -65,23 +65,24 @@ static connection_info* _ensure_connection_info(const char* ssid)
     }
 
     // Insert into ring buffer, overwriting oldest if necessary
-    int index = s_connection_history.next_index;
-    s_connection_history.next_index = \
-        (s_connection_history.next_index + 1) % CONNECTION_HISTORY_SIZE;
+    int index = s_network_history.next_index;
+    s_network_history.next_index = \
+        (s_network_history.next_index + 1) % NETWORK_HISTORY_SIZE;
 
-    connection_info* entry = &s_connection_history.connections[index];
+    network_info* entry = &s_network_history.used_networks[index];
     memset(entry, 0, sizeof(*entry));
     strncpy(entry->ssid, ssid, WIFI_MAX_SSID_LENGTH);
     entry->ssid[WIFI_MAX_SSID_LENGTH] = '\0';
     return entry;
 }
 
-static void _clear_connection_history()
+static void _clear_network_history()
 {
-    memset(&s_connection_history, 0, sizeof(s_connection_history));
+    memset(&s_network_history.used_networks, 0, sizeof(s_network_history.used_networks));
+    s_network_history.next_index = 0;
 }
 
-static void _block_network(connection_info* info)
+static void _block_network(network_info* info)
 {
     ESP_LOGI(
         TASK_NAME,
@@ -94,7 +95,7 @@ static void _block_network(connection_info* info)
 
 static bool _try_connect(wifi_network_credentials* creds)
 {
-    connection_info* info = _ensure_connection_info(creds->ssid);
+    network_info* info = _ensure_network_info(creds->ssid);
     if (info->blocked_until > esp_timer_get_time())
     {
         ESP_LOGD(TASK_NAME, "Skipped network '%s' due to temporary block", creds->ssid);
@@ -116,7 +117,7 @@ static bool _try_connect(wifi_network_credentials* creds)
 static bool _try_connect_prev()
 {
     wifi_network_credentials creds = {0};
-    if (!wifi_get_saved_network(s_prev_ssid, &creds))
+    if (!wifi_get_saved_network(s_network_history.prev_ssid, &creds))
     {
         // Can't connect if not saved
         return false;
@@ -150,7 +151,7 @@ static bool _try_autoconnect()
     return false;
 }
 
-static void task_connection_manager(void* data)
+static void task_network_manager(void* data)
 {
     // Future enhancements, probably overkill:
     // * Detect and avoid networks with rapidly changing RSSIs
@@ -159,7 +160,7 @@ static void task_connection_manager(void* data)
     //     Likely good enough to just check this on configuration and let our application layer handle it
     //     Technically gbplay will still work with no internet connection if hosted locally
     // * Prefer networks that previously had internet access over ones that didn't
-    //     New member of connection_info
+    //     New member of network_info
     // * Exponential backoff (for blacklisting and time between scans)
 
     while (true)
@@ -172,52 +173,53 @@ static void task_connection_manager(void* data)
             portMAX_DELAY
         );
 
-        if (bits & CONNECTION_EVENT_DROPPED)
+        if (bits & NETWORK_EVENT_DROPPED)
         {
-            ESP_LOGI(TASK_NAME, "Connection dropped");
-
-            // Try to reconnect
-            // Could have also been a false alarm (disconnect + reconnect by us)
-            while (!wifi_is_connected() && !_try_connect_prev() && !_try_autoconnect())
+            // Could have been a false alarm (disconnect + reconnect by us)
+            if (!wifi_is_connected())
             {
-                sleep(IDLE_SCAN_PERIOD_SECONDS);
-            }
+                ESP_LOGI(TASK_NAME, "Connection dropped");
 
-            ESP_LOGI(TASK_NAME, "Connection reestablished");
+                // Try to reconnect
+                while (!wifi_is_connected() && !_try_connect_prev() && !_try_autoconnect())
+                {
+                    sleep(IDLE_SCAN_PERIOD_SECONDS);
+                }
+            }
         }
-        else if (bits & CONNECTION_EVENT_LEFT)
+        else if (bits & NETWORK_EVENT_LEFT)
         {
             ESP_LOGI(TASK_NAME, "Left network voluntarily. Not attempting to reconnect.");
 
             // Deprioritize network the user chose to leave
-            connection_info* info = _ensure_connection_info(s_prev_ssid);
+            network_info* info = _ensure_network_info(s_network_history.prev_ssid);
             _block_network(info);
         }
-        else if (bits & CONNECTION_EVENT_CONNECTED)
+        else if (bits & NETWORK_EVENT_CONNECTED)
         {
-            ESP_LOGI(TASK_NAME, "Connected to network '%s'", s_prev_ssid);
+            ESP_LOGI(TASK_NAME, "Connected to network '%s'", s_network_history.prev_ssid);
 
-            _clear_connection_history();
+            _clear_network_history();
         }
     }
 }
 
-void task_connection_manager_start()
+void task_network_manager_start()
 {
     s_connection_event_group = xEventGroupCreate();
 
     ESP_ERROR_CHECK(esp_event_handler_instance_register(
-        CONNECTION_EVENT, CONNECTION_EVENT_DROPPED, &_on_disconnect, NULL, NULL
+        NETWORK_EVENT, NETWORK_EVENT_DROPPED, &_on_disconnect, NULL, NULL
     ));
     ESP_ERROR_CHECK(esp_event_handler_instance_register(
-        CONNECTION_EVENT, CONNECTION_EVENT_LEFT, &_on_leave, NULL, NULL
+        NETWORK_EVENT, NETWORK_EVENT_LEFT, &_on_leave, NULL, NULL
     ));
     ESP_ERROR_CHECK(esp_event_handler_instance_register(
-        CONNECTION_EVENT, CONNECTION_EVENT_CONNECTED, &_on_connect, NULL, NULL
+        NETWORK_EVENT, NETWORK_EVENT_CONNECTED, &_on_connect, NULL, NULL
     ));
 
     xTaskCreatePinnedToCore(
-        &task_connection_manager,
+        &task_network_manager,
         TASK_NAME,
         4096,                      // Stack size
         NULL,                      // Arguments
@@ -227,5 +229,5 @@ void task_connection_manager_start()
     );
 
     // Wake the task up and start looking for networks
-    xEventGroupSetBits(s_connection_event_group, CONNECTION_EVENT_DROPPED);
+    xEventGroupSetBits(s_connection_event_group, NETWORK_EVENT_DROPPED);
 }

--- a/esp/GBPlay/main/tasks/network_manager.h
+++ b/esp/GBPlay/main/tasks/network_manager.h
@@ -19,6 +19,6 @@
 
     The task is suspended when not trying to reconnect.
 */
-void task_network_manager_start();
+void task_network_manager_start(int core, int priority);
 
 #endif

--- a/esp/GBPlay/main/tasks/network_manager.h
+++ b/esp/GBPlay/main/tasks/network_manager.h
@@ -1,8 +1,8 @@
-#ifndef _CONNECTION_MANAGER_H
-#define _CONNECTION_MANAGER_H
+#ifndef _NETWORK_MANAGER_H
+#define _NETWORK_MANAGER_H
 
 /*
-    The connection manager tries to ensure a Wi-Fi connection.
+    The network manager tries to ensure a Wi-Fi connection.
     When the device is not connected to a network, the manager will:
 
       1. Try to reconnect to the previous network, if it was saved
@@ -19,6 +19,6 @@
 
     The task is suspended when not trying to reconnect.
 */
-void task_connection_manager_start();
+void task_network_manager_start();
 
 #endif

--- a/esp/GBPlay/main/tasks/socket_manager.c
+++ b/esp/GBPlay/main/tasks/socket_manager.c
@@ -1,0 +1,148 @@
+#include <freertos/FreeRTOS.h>
+#include <freertos/event_groups.h>
+#include <freertos/task.h>
+
+#include <esp_event.h>
+#include <esp_log.h>
+
+#include "../hardware/spi.h"
+#include "../hardware/storage.h"
+#include "../hardware/wifi.h"
+#include "socket.h"
+
+#define TASK_NAME "socket-manager"
+
+#define CONNECTION_TIMEOUT_MS 10000
+
+#define SERVER_HOST_STORAGE_KEY "server_host"
+#define SERVER_PORT_STORAGE_KEY "server_port"
+
+#define DEFAULT_SERVER_HOST "192.168.0.115"
+#define DEFAULT_SERVER_PORT 1989
+
+static TaskHandle_t s_socket_manager_task;
+
+static void _on_network_connect(void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data)
+{
+    // Wake up the task
+    xTaskNotify(s_socket_manager_task, 0, eNoAction);
+}
+
+static int _connect_to_server()
+{
+    bool should_free_host = true;
+
+    char* server_host = storage_get_string(SERVER_HOST_STORAGE_KEY);
+    if (server_host == NULL)
+    {
+        server_host = DEFAULT_SERVER_HOST;
+        should_free_host = false;
+    }
+
+    uint16_t server_port = DEFAULT_SERVER_PORT;
+    char* server_port_str = storage_get_string(SERVER_PORT_STORAGE_KEY);
+    if (server_port_str != NULL)
+    {
+        long ret = strtol(server_port_str, NULL, 10 /* base */);
+        if (ret == 0 || errno == ERANGE || ret > UINT16_MAX)
+        {
+            ESP_LOGW(
+                TASK_NAME,
+                "Configured server port %s is invalid. Using default port of %d.",
+                server_port_str,
+                server_port
+            );
+        }
+        else
+        {
+            server_port = ret;
+        }
+
+        free(server_port_str);
+    }
+
+    ESP_LOGI(TASK_NAME, "Connecting to backend server at %s:%d", server_host, server_port);
+
+    int sock = socket_connect(server_host, server_port, CONNECTION_TIMEOUT_MS);
+
+    if (should_free_host)
+    {
+        free(server_host);
+    }
+
+    return sock;
+}
+
+static void _handle_data_until_error(int sock)
+{
+    // TODO: abstract this to use a generic client, rather than socket
+    //  Will making it easier to handle different types of packets
+    while (true)
+    {
+        uint8_t rx = 0;
+        if (!socket_read(sock, &rx, sizeof(rx)))
+        {
+            break;
+        }
+
+        uint8_t tx = spi_exchange_byte(rx);
+        if (!socket_write(sock, &tx, sizeof(tx)))
+        {
+            break;
+        }
+    }
+}
+
+static void task_socket_manager(void *data)
+{
+    while (true)
+    {
+        if (!wifi_is_connected())
+        {
+            xTaskNotifyWait(
+                0,              // ulBitsToClearOnEntry
+                0,              // ulBitsToClearOnExit
+                NULL,           // pulNotificationValue
+                portMAX_DELAY   // xTicksToWait
+            );
+
+            ESP_LOGI(TASK_NAME, "Network connection established. Opening socket...");
+        }
+        else
+        {
+            ESP_LOGI(TASK_NAME, "Retrying socket connection...");
+        }
+
+        int sock = _connect_to_server();
+        if (sock < 0)
+        {
+            ESP_LOGE(TASK_NAME, "Failed to connect to backend server");
+        }
+        else
+        {
+            ESP_LOGI(TASK_NAME, "Successfully connected to backend server");
+
+            _handle_data_until_error(sock);
+
+            ESP_LOGI(TASK_NAME, "Closing socket");
+            close(sock);
+        }
+    }
+}
+
+void task_socket_manager_start(int core, int priority)
+{
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(
+        NETWORK_EVENT, NETWORK_EVENT_CONNECTED, &_on_network_connect, NULL, NULL
+    ));
+
+    xTaskCreatePinnedToCore(
+        &task_socket_manager,
+        TASK_NAME,
+        4096,                   // Stack size
+        NULL,                   // Arguments
+        priority,               // Priority
+        &s_socket_manager_task, // Task handle (output parameter)
+        core                    // CPU core ID
+    );
+}

--- a/esp/GBPlay/main/tasks/socket_manager.h
+++ b/esp/GBPlay/main/tasks/socket_manager.h
@@ -1,0 +1,9 @@
+#ifndef _SOCKET_MANAGER_H
+#define _SOCKET_MANAGER_H
+
+/*
+    Maintains a socket connection to the backend server.
+*/
+void task_socket_manager_start(int core, int priority);
+
+#endif

--- a/esp/GBPlay/main/tasks/status_indicator.c
+++ b/esp/GBPlay/main/tasks/status_indicator.c
@@ -22,15 +22,15 @@ static void task_status_indicator(void* data)
     }
 }
 
-void task_status_indicator_start()
+void task_status_indicator_start(int core, int priority)
 {
     xTaskCreatePinnedToCore(
         &task_status_indicator,
         TASK_NAME,
         configMINIMAL_STACK_SIZE,  // Stack size
         NULL,                      // Arguments
-        0,                         // Priority
+        priority,                  // Priority
         NULL,                      // Task handle (output parameter)
-        0                          // CPU core ID
+        core                       // CPU core ID
     );
 }

--- a/esp/GBPlay/main/tasks/status_indicator.h
+++ b/esp/GBPlay/main/tasks/status_indicator.h
@@ -6,6 +6,6 @@
 
     Solid if connected to Wi-Fi, otherwise blinking.
 */
-void task_status_indicator_start();
+void task_status_indicator_start(int core, int priority);
 
 #endif


### PR DESCRIPTION
This is based off of PR #13, with added error checking and integration with the SPI code from PR #19.

The new socket manager task will block until the device connects to a network. It will then try to connect to the backend server (address is configurable). Once a connection has been made, the device will forward each byte it receives from the server to the connected Game Boy and vice versa. I have successfully been able to use this setup to play multiplayer Tetris games over LAN.

We now have what we need to easily test over the internet together. I plan to work on the front-end next (configuring which game will be played, joining game lobbies, etc.).