### PR TITLE
esp: update readme with IDF version

### DIFF
--- a/esp/GBPlay/README.md
+++ b/esp/GBPlay/README.md
@@ -1,3 +1,3 @@
 # GBPlay hardware code
 
-This code is meant to be compiled using the ESP idf SDK.
+This code is meant to be compiled using the ESP idf SDK v4.4.x.


### PR DESCRIPTION
As I wasn't able to compile the esp code at first, I had to add these includes to make it work.
Please mind: I'm using Linux, and the differences in includes requirements might come from here.
If this compiles in Windows as well, there should be no drawback in merging those.

Added bonus: added the sdkconfig file to the gitignore file as  suggested by the [esp32 doc](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/kconfig.html).
